### PR TITLE
feat: CPU batch size calibration + v0.1.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,3 +82,14 @@ jobs:
             rawq-linux-x86_64.tar.gz
             rawq-macos-aarch64.tar.gz
           generate_release_notes: true
+
+  publish:
+    name: Publish to crates.io
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.onnx
 models/
 .claude/
+CLAUDE.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1785,7 +1785,7 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rawq"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1989,9 +1989,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rawq"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/auyelbekov/rawq"

--- a/src/embed/calibrate.rs
+++ b/src/embed/calibrate.rs
@@ -1,0 +1,310 @@
+//! CPU batch size auto-calibration.
+//!
+//! On CPU, there is no fixed VRAM wall — the optimal batch size depends on
+//! the specific CPU, cache hierarchy, and model. Instead of guessing with a
+//! hardcoded memory budget, we measure: double the batch size until throughput
+//! stops improving, then cache the result.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+use std::time::Instant;
+
+use serde::{Deserialize, Serialize};
+
+use super::Embedder;
+
+/// Synthetic text that resembles a real code chunk (~200 tokens).
+const CALIBRATION_TEXT: &str = "\
+/// Process a batch of items with the given configuration.\n\
+fn process_items(items: &[Item], config: &Config) -> Result<Vec<Output>> {\n\
+    let mut results = Vec::with_capacity(items.len());\n\
+    for item in items {\n\
+        let validated = validate(item, &config.rules)?;\n\
+        let transformed = transform(&validated, config)?;\n\
+        results.push(transformed);\n\
+    }\n\
+    Ok(results)\n\
+}\n";
+
+/// Minimum improvement ratio to keep doubling. If throughput doesn't improve
+/// by at least this factor, we've hit the plateau.
+const IMPROVEMENT_THRESHOLD: f64 = 1.05;
+
+/// Maximum batch size to try during calibration.
+const MAX_CALIBRATION_BATCH: usize = 128;
+
+/// Maximum wall-clock time for the entire calibration (seconds).
+const MAX_CALIBRATION_SECS: f64 = 3.0;
+
+// ── Cache ────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize, Deserialize)]
+struct CalibrationEntry {
+    batch_size: usize,
+    throughput: f64,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct CalibrationCache {
+    entries: HashMap<String, CalibrationEntry>,
+}
+
+fn cache_path() -> Option<PathBuf> {
+    dirs::cache_dir().map(|d| d.join("rawq").join("calibration.json"))
+}
+
+fn cache_key(model_name: &str, cpu_model: &str) -> String {
+    format!("{model_name}::{cpu_model}")
+}
+
+fn load_cache() -> CalibrationCache {
+    let Some(path) = cache_path() else {
+        return CalibrationCache::default();
+    };
+    fs::read_to_string(path)
+        .ok()
+        .and_then(|data| serde_json::from_str(&data).ok())
+        .unwrap_or_default()
+}
+
+fn save_cache(cache: &CalibrationCache) {
+    let Some(path) = cache_path() else { return };
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    if let Ok(data) = serde_json::to_string_pretty(cache) {
+        let _ = fs::write(path, data);
+    }
+}
+
+// ── CPU detection ────────────────────────────────────────────────────────
+
+/// Detect the CPU model string for use as a cache key.
+pub fn detect_cpu_model() -> String {
+    detect_cpu_model_inner().unwrap_or_else(|| "unknown-cpu".to_string())
+}
+
+#[cfg(target_os = "windows")]
+fn detect_cpu_model_inner() -> Option<String> {
+    let output = std::process::Command::new("reg")
+        .args([
+            "query",
+            r"HKLM\HARDWARE\DESCRIPTION\System\CentralProcessor\0",
+            "/v",
+            "ProcessorNameString",
+        ])
+        .output()
+        .ok()?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for line in stdout.lines() {
+        if line.contains("ProcessorNameString") {
+            let value = line.rsplit("REG_SZ").next()?.trim();
+            if !value.is_empty() {
+                return Some(sanitize_cpu_name(value));
+            }
+        }
+    }
+    None
+}
+
+#[cfg(target_os = "linux")]
+fn detect_cpu_model_inner() -> Option<String> {
+    let cpuinfo = fs::read_to_string("/proc/cpuinfo").ok()?;
+    for line in cpuinfo.lines() {
+        if line.starts_with("model name") {
+            let value = line.split(':').nth(1)?.trim();
+            if !value.is_empty() {
+                return Some(sanitize_cpu_name(value));
+            }
+        }
+    }
+    None
+}
+
+#[cfg(target_os = "macos")]
+fn detect_cpu_model_inner() -> Option<String> {
+    let output = std::process::Command::new("sysctl")
+        .args(["-n", "machdep.cpu.brand_string"])
+        .output()
+        .ok()?;
+    let name = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if name.is_empty() {
+        None
+    } else {
+        Some(sanitize_cpu_name(&name))
+    }
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "linux", target_os = "macos")))]
+fn detect_cpu_model_inner() -> Option<String> {
+    None
+}
+
+/// Replace whitespace/special chars with underscores for safe cache keys.
+fn sanitize_cpu_name(name: &str) -> String {
+    name.chars()
+        .map(|c| {
+            if c.is_alphanumeric() || c == '-' || c == '.' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>()
+        // Collapse repeated underscores
+        .split('_')
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join("_")
+}
+
+// ── Calibration ──────────────────────────────────────────────────────────
+
+/// Measure throughput for a given batch size (median of `runs` attempts).
+fn measure_throughput(embedder: &mut Embedder, bs: usize, runs: usize) -> Option<f64> {
+    let batch: Vec<&str> = vec![CALIBRATION_TEXT; bs];
+    let mut times = Vec::with_capacity(runs);
+    for _ in 0..runs {
+        let t = Instant::now();
+        if embedder.embed(&batch).is_err() {
+            return None;
+        }
+        times.push(t.elapsed().as_secs_f64());
+    }
+    times.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let median = times[times.len() / 2];
+    Some(bs as f64 / median)
+}
+
+/// Run the calibration loop: warmup, then double batch size until throughput
+/// plateaus. Returns (optimal_batch_size, throughput_items_per_sec).
+fn run_calibration(embedder: &mut Embedder) -> (usize, f64) {
+    let cal_start = Instant::now();
+
+    // Warmup: multiple runs to stabilize ONNX thread pool, memory allocator,
+    // and OS page faults. A single warmup leaves batch=2+ artificially slow
+    // because they touch new memory pages for the first time.
+    for bs in [1, 2, 4] {
+        let batch: Vec<&str> = vec![CALIBRATION_TEXT; bs];
+        let _ = embedder.embed(&batch);
+    }
+
+    // Measure each batch size with 3 runs (take median to filter noise)
+    let mut best_size = 1usize;
+    let mut best_throughput = measure_throughput(embedder, 1, 3).unwrap_or(1.0);
+    let mut plateaus = 0u32;
+
+    let mut bs = 2usize;
+    while bs <= MAX_CALIBRATION_BATCH {
+        if cal_start.elapsed().as_secs_f64() > MAX_CALIBRATION_SECS {
+            break;
+        }
+
+        match measure_throughput(embedder, bs, 3) {
+            Some(throughput) => {
+                if throughput > best_throughput * IMPROVEMENT_THRESHOLD {
+                    best_size = bs;
+                    best_throughput = throughput;
+                    plateaus = 0;
+                } else {
+                    // Require two consecutive plateaus to confirm — a single
+                    // flat step can be noise from OS scheduling or cache effects.
+                    plateaus += 1;
+                    if plateaus >= 2 {
+                        break;
+                    }
+                }
+            }
+            None => {
+                break;
+            }
+        }
+
+        bs *= 2;
+    }
+
+    (best_size, best_throughput)
+}
+
+/// Return the calibrated CPU batch size for this embedder.
+///
+/// Checks cache first; runs calibration if no cached result or if
+/// `RAWQ_RECALIBRATE=1` is set.
+pub fn calibrated_batch_size(embedder: &mut Embedder) -> usize {
+    let cpu = detect_cpu_model();
+    let key = cache_key(embedder.model_name(), &cpu);
+    let force = std::env::var("RAWQ_RECALIBRATE").is_ok();
+
+    if !force {
+        let cache = load_cache();
+        if let Some(entry) = cache.entries.get(&key) {
+            eprintln!(
+                "  CPU batch size: {} (cached, {:.0} items/s)",
+                entry.batch_size, entry.throughput
+            );
+            return entry.batch_size;
+        }
+    }
+
+    eprintln!("  Calibrating CPU batch size...");
+    let (batch_size, throughput) = run_calibration(embedder);
+    eprintln!(
+        "  CPU batch size: {} (calibrated, {:.0} items/s)",
+        batch_size, throughput
+    );
+
+    let mut cache = load_cache();
+    cache.entries.insert(
+        key,
+        CalibrationEntry {
+            batch_size,
+            throughput,
+        },
+    );
+    save_cache(&cache);
+
+    batch_size
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cpu_model_detection() {
+        let cpu = detect_cpu_model();
+        assert!(!cpu.is_empty());
+        assert!(!cpu.contains(' '));
+    }
+
+    #[test]
+    fn sanitize_cpu_name_works() {
+        assert_eq!(
+            sanitize_cpu_name("Intel(R) Core(TM) i7-10750H CPU @ 2.60GHz"),
+            "Intel_R_Core_TM_i7-10750H_CPU_2.60GHz"
+        );
+        assert_eq!(sanitize_cpu_name("Apple M2 Pro"), "Apple_M2_Pro");
+    }
+
+    #[test]
+    fn cache_key_format() {
+        let key = cache_key("snowflake-arctic-embed-s", "Intel_Core_i7");
+        assert_eq!(key, "snowflake-arctic-embed-s::Intel_Core_i7");
+    }
+
+    #[test]
+    fn cache_roundtrip() {
+        let mut cache = CalibrationCache::default();
+        cache.entries.insert(
+            "test::cpu".to_string(),
+            CalibrationEntry {
+                batch_size: 16,
+                throughput: 42.5,
+            },
+        );
+        let json = serde_json::to_string(&cache).unwrap();
+        let loaded: CalibrationCache = serde_json::from_str(&json).unwrap();
+        assert_eq!(loaded.entries["test::cpu"].batch_size, 16);
+    }
+}

--- a/src/embed/mod.rs
+++ b/src/embed/mod.rs
@@ -1,3 +1,4 @@
+pub mod calibrate;
 pub mod config;
 pub mod error;
 pub mod gpu;

--- a/src/index/pipeline.rs
+++ b/src/index/pipeline.rs
@@ -21,21 +21,17 @@ use crate::index::chunker;
 /// The per-item cost accounts for both input tensors and transformer
 /// attention/activation memory, which scales with seq_len² and dominates
 /// actual GPU usage.
-fn batch_size_for(embedder: &Embedder, override_size: Option<usize>) -> usize {
+fn batch_size_for(embedder: &mut Embedder, override_size: Option<usize>) -> usize {
     if let Some(bs) = override_size {
         return bs.clamp(1, 128);
     }
+    if !embedder.uses_gpu() {
+        // CPU: measure real throughput instead of guessing a memory budget.
+        return crate::embed::calibrate::calibrated_batch_size(embedder);
+    }
+    // GPU: compute from detected VRAM (a real, measurable hardware limit).
     let dim = embedder.embed_dim();
     let seq_len = embedder.max_seq_len();
-    // Transformer forward pass memory per item:
-    //   input tensor: dim * seq_len * 4
-    //   attention matrices: O(seq_len²) per head per layer — dominates for long sequences
-    //   activations: proportional to dim * seq_len per layer
-    // We approximate total per-item cost by scaling the input tensor size
-    // by a seq_len-dependent activation factor: (seq_len / 6), floor at 4.
-    // This captures the quadratic attention scaling (Q*K^T scores, FFN intermediates)
-    // without needing model internals. Empirically validated: Snowflake (512 seq)
-    // on 6 GB GPU handles batch≈64 → real per-item ≈ 69 MB, factor ≈ 87 ≈ 512/6.
     let activation_factor = (seq_len / 6).max(4);
     let per_item = match dim
         .checked_mul(seq_len)
@@ -43,25 +39,19 @@ fn batch_size_for(embedder: &Embedder, override_size: Option<usize>) -> usize {
         .and_then(|v| v.checked_mul(activation_factor))
     {
         Some(v) if v > 0 => v,
-        _ => return 1, // overflow or zero → safest batch size
+        _ => return 1,
     };
-    let mem_limit: usize = if embedder.uses_gpu() {
-        std::env::var("RAWQ_VRAM_BUDGET")
-            .ok()
-            .and_then(|v| v.parse::<usize>().ok())
-            .unwrap_or_else(|| {
-                let vram = embedder.gpu_vram();
-                if vram > 0 {
-                    // Use 75% of detected VRAM to leave headroom for OS/other apps
-                    ((vram / 4) * 3) as usize
-                } else {
-                    // Detection failed — conservative 2 GB fallback
-                    2 * 1024 * 1024 * 1024
-                }
-            })
-    } else {
-        512 * 1024 * 1024 // 512 MB for CPU
-    };
+    let mem_limit: usize = std::env::var("RAWQ_VRAM_BUDGET")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or_else(|| {
+            let vram = embedder.gpu_vram();
+            if vram > 0 {
+                ((vram / 4) * 3) as usize
+            } else {
+                2 * 1024 * 1024 * 1024
+            }
+        });
     let computed = mem_limit / per_item;
     computed.max(1)
 }
@@ -638,12 +628,13 @@ fn embed_texts_with_progress(
     batch_size_override: Option<usize>,
 ) -> Result<Vec<Vec<f32>>> {
     let mut batch_size = batch_size_for(embedder, batch_size_override);
-    eprintln!(
-        "  Batch size: {} (gpu={}, vram={:.1} GB)",
-        batch_size,
-        embedder.uses_gpu(),
-        embedder.gpu_vram() as f64 / (1024.0 * 1024.0 * 1024.0),
-    );
+    if embedder.uses_gpu() {
+        eprintln!(
+            "  Batch size: {} (vram={:.1} GB)",
+            batch_size,
+            embedder.gpu_vram() as f64 / (1024.0 * 1024.0 * 1024.0),
+        );
+    }
     let mut all_embeddings = Vec::with_capacity(texts.len());
     let mut offset = 0;
     let mut pb: Option<ProgressBar> = None;


### PR DESCRIPTION
## Summary
- Replace hardcoded 512 MB CPU memory budget with runtime calibration that measures actual throughput
- Add `src/embed/calibrate.rs`: CPU detection (Windows/Linux/macOS), calibration loop (warmup → double until plateau), result caching at `~/.cache/rawq/calibration.json`
- GPU batch sizing path unchanged (VRAM-based math is already hardware-grounded)
- Fix duplicate/misleading batch size log line for CPU users
- Bump version to 0.1.1
- Add `cargo publish` job to release CI (requires `CARGO_REGISTRY_TOKEN` secret)

## Test plan
- [x] `cargo clippy -- -D warnings` passes with zero warnings
- [x] `cargo test` passes (65 tests: 39 unit + 7 embed + 19 search)
- [x] Manual test: `rawq index build .` on CPU shows calibration output
- [x] CI: clippy + test on Windows, Linux, macOS
- [ ] CI: build with directml, cuda, coreml features